### PR TITLE
Fix/us16

### DIFF
--- a/app/controllers/streaming_service_shows_controller.rb
+++ b/app/controllers/streaming_service_shows_controller.rb
@@ -1,7 +1,11 @@
 class StreamingServiceShowsController < ApplicationController
   def index
     @streaming_service = StreamingService.find(params[:id])
-    @shows = @streaming_service.shows
+    if params[:sort] == "alpha"
+      @shows = @streaming_service.shows.order_by_name
+    else
+      @shows = @streaming_service.shows
+    end
   end
 
   def new

--- a/app/views/streaming_service_shows/index.html.erb
+++ b/app/views/streaming_service_shows/index.html.erb
@@ -2,6 +2,9 @@
 <a href="/streaming_services">Streaming Services Index</a>
 
 <h2><%= @streaming_service.name %>'s Shows</h2><br/>
+
+<%= link_to "Sort #{@streaming_service.name}'s Shows Alphabetically", "/streaming_services/#{@streaming_service.id}/shows?sort=alpha"%><br/><br/>
+
 <% @shows.each do |show| %>
   <h3><%= show.name %> <%= link_to "Update #{show.name}", "/shows/#{show.id}/edit" %></h3>
   <p>Genre: <%= show.genre %></p>

--- a/spec/features/streaming_services/shows/index_spec.rb
+++ b/spec/features/streaming_services/shows/index_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Shows Index", type: :feature do
 
         expect(current_path).to eq("/streaming_services/#{@netflix.id}/shows")
 
-        expect(@is_it_cake).to appear_before(@the_witcher)
+        expect(@is_it_cake.name).to appear_before(@the_witcher.name)
       end
 
       it "has links to update Netflix's shows" do


### PR DESCRIPTION
## Description

- Added code to implement link to shows sorted alphabetically by name when clicked (User Story 16)
- Fixed test for this link to look for the name of the earlier sorted object to appear before the name of the later sorted object, rather than one object itself appearing before the other

## Type of change

- [x] fix
- [x] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!
